### PR TITLE
remove mutable defaut argument

### DIFF
--- a/pytchat/core/pytchat.py
+++ b/pytchat/core/pytchat.py
@@ -61,7 +61,7 @@ class PytchatCore:
     def __init__(self, video_id,
                  seektime=-1,
                  processor=DefaultProcessor(),
-                 client = httpx.Client(http2=True),
+                 client=None,
                  interruptable=True,
                  force_replay=False,
                  topchat_only=False,
@@ -69,6 +69,8 @@ class PytchatCore:
                  logger=config.logger(__name__),
                  replay_continuation=None
                  ):
+        if client is None:
+            client = httpx.Client(http2=True)
         self._client = client
         self._video_id = util.extract_video_id(video_id)
         self.seektime = seektime

--- a/pytchat/core_async/livechat.py
+++ b/pytchat/core_async/livechat.py
@@ -78,7 +78,7 @@ class LiveChatAsync:
                  seektime=-1,
                  processor=DefaultProcessor(),
                  buffer=None,
-                 client = httpx.AsyncClient(http2=True),
+                 client=None,
                  interruptable=True,
                  callback=None,
                  done_callback=None,
@@ -89,6 +89,8 @@ class LiveChatAsync:
                  logger=config.logger(__name__),
                  replay_continuation=None
                  ):
+        if client is None:
+            client = httpx.AsyncClient(http2=True)
         self._client:httpx.AsyncClient = client
         self._video_id = util.extract_video_id(video_id)
         self.member_stream = util.is_member_stream(self._video_id)

--- a/pytchat/core_multithread/livechat.py
+++ b/pytchat/core_multithread/livechat.py
@@ -78,7 +78,7 @@ class LiveChat:
     def __init__(self, video_id,
                  seektime=-1,
                  processor=DefaultProcessor(),
-                 client = httpx.Client(http2=True),
+                 client=None,
                  buffer=None,
                  interruptable=True,
                  callback=None,
@@ -89,6 +89,8 @@ class LiveChat:
                  logger=config.logger(__name__),
                  replay_continuation=None
                  ):
+        if client is None:
+            client = httpx.Client(http2=True)
         self._client = client
         self._video_id = util.extract_video_id(video_id)
         self.seektime = seektime


### PR DESCRIPTION
**Setting the httpx.Client with a default argument results in the same client being reused for every chat created.**
---
For example, when running this script...
```
import pytchat

for x in range(0, 5):
    chat = pytchat.create('jfKfPfyJRdk')
    print(chat._client)
```
every chat instance uses the same httpx.Client object.
```
C:\Users\Hash\IDLE\pytchat>python test2.py
<httpx.Client object at 0x000001CE2AF13C10>
<httpx.Client object at 0x000001CE2AF13C10>
<httpx.Client object at 0x000001CE2AF13C10>
<httpx.Client object at 0x000001CE2AF13C10>
<httpx.Client object at 0x000001CE2AF13C10>
```

The proposed changes will change the output to something like this:
```
C:\Users\Hash\IDLE\pytchat>python test2.py
<httpx.Client object at 0x00000197279E8510>
<httpx.Client object at 0x000001972A44F710>
<httpx.Client object at 0x000001972A444FD0>
<httpx.Client object at 0x000001972A464590>
<httpx.Client object at 0x000001972A434310>
```
---

The current code is problematic because a single closed client connection causes all chats to fail. Creating a new client does not fix this either. This can be shown by running this code:

```
import pytchat

# create a new chat
chat = pytchat.create(video_id = 'jfKfPfyJRdk')

# close connection to simulate an error
chat._client.close()

# create a new chat. this fails because the httpx.client is reused when it is a default argument
chat = pytchat.create(video_id = 'jfKfPfyJRdk')

# this code never runs :(
while chat.is_alive():
    for c in chat.get().sync_items():
        print(f"{c.datetime} [{c.author.name}]- {c.message}")
```
which results in this error:
```
C:\Users\Hash\IDLE\pytchat>python test.py
Traceback (most recent call last):
  File "C:\Users\Hash\IDLE\pytchat\test.py", line 10, in <module>
    chat = pytchat.create(video_id = 'jfKfPfyJRdk')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\pytchat\core\__init__.py", line 7, in create
    return PytchatCore(_vid, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\pytchat\core\pytchat.py", line 96, in __init__
    self._setup()
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\pytchat\core\pytchat.py", line 106, in _setup
    channel_id=util.get_channelid(self._client, self._video_id),
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\pytchat\util\__init__.py", line 103, in get_channelid
    resp = client.get("https://www.youtube.com/embed/{}".format(quote(video_id)), headers=config.headers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\httpx\_client.py", line 1045, in get
    return self.request(
           ^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\httpx\_client.py", line 821, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Hash\AppData\Roaming\Python\Python311\site-packages\httpx\_client.py", line 897, in send
    raise RuntimeError("Cannot send a request, as the client has been closed.")
RuntimeError: Cannot send a request, as the client has been closed.
```